### PR TITLE
[PUZSOC-552] fixing a plugin vs extend mixup, adding preset-env

### DIFF
--- a/javascript/es6/formatters/README.md
+++ b/javascript/es6/formatters/README.md
@@ -22,11 +22,12 @@ To use the demo config, also install these packages:
 yarn add eslint-config-prettier --dev
 ```
 
-That config will disable any formatting rules in ESLint that conflict with Prettier. After installing `eslint-config-prettier`, update the ESLint config to use the new Prettier plugin. This example show how to update our [recommended ESLint config](https://github.com/Andrews-McMeel-Universal/amu-code_standards/tree/production/javascript/es6/linters).
+That config will disable any formatting rules in ESLint that conflict with Prettier. After installing `eslint-config-prettier`, update the ESLint config to use the new Prettier config. This example show how to update our [recommended ESLint config](https://github.com/Andrews-McMeel-Universal/amu-code_standards/tree/production/javascript/es6/linters):
 
 ```diff
+# .eslintrc.json
 {
--  "plugins": ["babel"]
-+  "plugins": ["babel", "prettier"]
+   "plugins": ["babel"],
++  "extends": ["prettier"]
 }
 ```

--- a/javascript/es6/transpilers/README.md
+++ b/javascript/es6/transpilers/README.md
@@ -16,13 +16,13 @@ yarn add babel-loader @babel/core
 
 Please see the [Babel documentation](https://babeljs.io/docs/en/config-files/) to configure it for the project's needs. Here you'll find a sample `babel.config.json` (the config file).
 
-To use the demo config, also install this package:
+To use the demo config, also install these packages:
 
 ```bash
-yarn add babel-preset-airbnb
+yarn add babel-preset-airbnb && yarn add @babel/preset-env --dev
 ```
 
-It uses [babel-preset-airbnb](https://github.com/airbnb/babel-preset-airbnb) to provide sensible defaults that are compatible with our adopted coding standards.
+It uses [babel-preset-env](https://babeljs.io/docs/en/babel-preset-env) to assist with supporting different target environments, and [babel-preset-airbnb](https://github.com/airbnb/babel-preset-airbnb) to provide sensible defaults that are compatible with our adopted coding standards.
 
 ## Polyfills
 

--- a/javascript/es6/transpilers/babel.config.json
+++ b/javascript/es6/transpilers/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["@babel/preset-env", "airbnb"]
 }


### PR DESCRIPTION
## Description
Fix for plugins vs extends, added missing `preset-env` to Babel docs.

- [x] This is appropriate for public visibility

## Links

* Jira Issue: PUZSOC-552
